### PR TITLE
Corregida posición del grupo de iconos

### DIFF
--- a/View/Master/MenuTemplate.html.twig
+++ b/View/Master/MenuTemplate.html.twig
@@ -110,7 +110,7 @@
                             {{ macros.showMenu(menuItem) }}
                         {% endfor %}
                     </ul>
-                    <ul class="navbar-nav flex-row ml-auto">
+                    <ul class="navbar-nav flex-row ms-auto">
                         {% block navbarMenuIcon %}
                             {% for item in getIncludeViews('MenuTemplate', 'MenuIconBefore') %}
                                 {% include item['path'] %}


### PR DESCRIPTION
Sustituida la clase ml-auto por ms-auto para que posicione correctamente la barra de iconos en la parte superior del menú.